### PR TITLE
Upgrade GitHub actions versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
         id: branch_name
         run: echo ::set-output name=TARBALL::grammarly-embrace-${GITHUB_REF#refs/tags/}.tgz
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - run: yarn install
       - run: yarn build
       - run: yarn test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,9 +12,9 @@ jobs:
         node-version: [12.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - run: yarn install


### PR DESCRIPTION
* Use actions/checkout v4
* Use actions/setup-node v4

This fixes the following warning:

> The following actions uses node12 which is deprecated and will be forced to run on node16:
> actions/checkout@v2, actions/setup-node@v1.
> For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

You can see the warning here: https://github.com/grammarly/embrace/actions/runs/7049081075