### PR TITLE
Avoid using set-output in GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Branch name
         id: branch_name
-        run: echo ::set-output name=TARBALL::grammarly-embrace-${GITHUB_REF#refs/tags/}.tgz
+        run: echo "TARBALL=grammarly-embrace-${GITHUB_REF#refs/tags/}.tgz" >> $GITHUB_OUTPUT
       - name: Checkout code
         uses: actions/checkout@v4
       - run: yarn install


### PR DESCRIPTION
We should update it to the new style per [the docs](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

You can see the warning at the bottom of this run of the `release` workflow: https://github.com/grammarly/embrace/actions/runs/7104082636